### PR TITLE
Adds 'shift' class to top-of-page 'tablesorter' tables

### DIFF
--- a/source/ipmi/usr/local/emhttp/plugins/ipmi/IPMIArchive.page
+++ b/source/ipmi/usr/local/emhttp/plugins/ipmi/IPMIArchive.page
@@ -4,7 +4,7 @@ Tag="save"
 Markdown="false"
 ---
 <div>
-    <table class="tablesorter hover-highlight archive" id="tblArchive">
+    <table class="tablesorter shift hover-highlight archive" id="tblArchive">
         <thead>
             <tr>
                 <th class="sorter-false filter-false"> Status </th>

--- a/source/ipmi/usr/local/emhttp/plugins/ipmi/IPMIEvents.page
+++ b/source/ipmi/usr/local/emhttp/plugins/ipmi/IPMIEvents.page
@@ -5,7 +5,7 @@ Markdown="false"
 ---
 <div>
     <span id="arch-switch" class="status"><input type="checkbox" id="event-arch"></span>
-    <table class="tablesorter hover-highlight events" id="tblEvent">
+    <table class="tablesorter shift hover-highlight events" id="tblEvent">
         <thead>
             <tr>
                 <th class="sorter-false filter-false"> Status </th>

--- a/source/ipmi/usr/local/emhttp/plugins/ipmi/IPMISensors.page
+++ b/source/ipmi/usr/local/emhttp/plugins/ipmi/IPMISensors.page
@@ -19,7 +19,7 @@ table.tablesorter tbody tr:nth-child(even) {
 
 <div>
     <span id="adv-switch" class="status"><input type='checkbox' id='advancedview'></span>
-    <table class="tablesorter hover-highlight sensors" id="tblSensor">
+    <table class="tablesorter shift hover-highlight sensors" id="tblSensor">
         <thead>
             <tr>
                 <th class="sorter-false filter-false"> Status </th>


### PR DESCRIPTION
The tables in the "sensors", "events", and "archived events" pages are missing the `shift` class that is responsible for eliminating the whitespace the otherwise appears between the tabs and the tables.

### Without 'shift' class:
![Screen Shot 2023-11-19 at 1 05 45 PM](https://github.com/SimonFair/IPMI-unRAID/assets/101997244/bb5c9a17-0389-4f4d-b6b6-0ee3854e512f)
### With 'shift' class:
![Screen Shot 2023-11-19 at 1 06 07 PM](https://github.com/SimonFair/IPMI-unRAID/assets/101997244/04ea3fd0-2b93-4298-8937-ef93879c50cc)

For an example of the `shift` class being used to correctly eliminate the unnecessary whitespace in the main dynamix GUI check the `Plugins.page` file which defines its primary table using the following syntax: `<table class='tablesorter plugins shift' id='plugin_table'>`