### PR TITLE
Add giga support

### DIFF
--- a/source/ipmi/usr/local/emhttp/plugins/ipmi/IPMIFans.page
+++ b/source/ipmi/usr/local/emhttp/plugins/ipmi/IPMIFans.page
@@ -200,6 +200,20 @@ if(is_file($log)){
 </table>
 <?endif;?>
 
+<style>
+.fanctrl-settings { display: none; }
+</style>
+
+<script>
+// Hide all fanctrl-settings immediately to prevent flash before jQuery runs
+document.addEventListener('DOMContentLoaded', function() {
+    var elements = document.querySelectorAll('.fanctrl-settings');
+    for (var i = 0; i < elements.length; i++) {
+        elements[i].style.display = 'none';
+    }
+});
+</script>
+
 <script>
 $(function(){
     <?if ($board_status !== false):?>
@@ -239,7 +253,8 @@ $(function(){
         var spindownSelector = "select[name='TEMPHDD_" + fanSuffix + "']";
         var detailClass = '.fan-spindown-' + fanSuffix;
         var spindownValue = parseInt($(spindownSelector).val() || '0', 10);
-        var showDetails = ($(primarySelector).val() === '99') && (spindownValue > 0) && !$(spindownSelector).prop('disabled');
+        var showAdvanced = ($.cookie('fanctrl_view_mode') == 'advanced');
+        var showDetails = showAdvanced && ($(primarySelector).val() === '99') && (spindownValue > 0) && !$(spindownSelector).prop('disabled');
         $(detailClass).toggle(showDetails);
     }
 
@@ -278,14 +293,11 @@ $(function(){
 
     $('.fanctrl-enable')
         .each(function() {
-            var fanClass = '.fan-config-' + $(this).data('fan');
-            $(fanClass).toggle($(this).val() !== '0');
             $(this).closest('.fan-block').attr('data-enabled', ($(this).val() === '0') ? '0' : '1');
         })
         .on('change', function() {
-            var fanClass = '.fan-config-' + $(this).data('fan');
-            $(fanClass).toggle($(this).val() !== '0');
             $(this).closest('.fan-block').attr('data-enabled', ($(this).val() === '0') ? '0' : '1');
+            syncFanConfigVisibility();
             sortFanBlocks();
         });
 
@@ -349,6 +361,15 @@ function sortFanBlocks() {
     });
 }
 
+function syncFanConfigVisibility() {
+    var showAdvanced = ($.cookie('fanctrl_view_mode') == 'advanced');
+    $('.fanctrl-enable').each(function() {
+        var fanClass = '.fan-config-' + $(this).data('fan');
+        var fanEnabled = ($(this).val() !== '0');
+        $(fanClass).toggle(showAdvanced && fanEnabled);
+    });
+}
+
 function checkFANCTRL() {
     if ($('#FANCONTROL')[0].selectedIndex < 1 ) {
         $('#FANCMD').val('/usr/local/emhttp/plugins/ipmi/scripts/fanctrl_stop');
@@ -381,6 +402,7 @@ function toggleFanCTRL() {
         $('.fanctrl-basic').show();
         $('.fanctrl-settings').hide();
     }
+    syncFanConfigVisibility();
 }
 <?endif;?>
 </script>

--- a/source/ipmi/usr/local/emhttp/plugins/ipmi/IPMIFans.page
+++ b/source/ipmi/usr/local/emhttp/plugins/ipmi/IPMIFans.page
@@ -2,7 +2,7 @@ Menu="IPMI:2"
 Title="Fan Control"
 Tag="thermometer"
 Markdown="false"
-Cond="exec(\"grep -o '^OVERRIDE=.enable' /boot/config/plugins/ipmi/ipmi.cfg 2>/dev/null\") || array_key_exists(trim(shell_exec(\"dmidecode -t 2 | grep 'Manufacturer' | awk -F 'r:' '{print $2}' | awk '{print $1}'\")), ['ASRock'=>'','ASRockRack'=>'','Dell'=>'','Supermicro'=>''])"
+Cond="exec(\"grep -o '^OVERRIDE=.enable' /boot/config/plugins/ipmi/ipmi.cfg 2>/dev/null\") || array_key_exists(trim(shell_exec(\"dmidecode -t 2 | grep 'Manufacturer' | awk -F 'r:' '{print $2}' | awk '{print $1}'\")), ['ASRock'=>'','ASRockRack'=>'','Dell'=>'','Supermicro'=>'','Giga'=>''])"
 ---
 
 <div id="title" style="margin-top: -22px;">
@@ -228,18 +228,68 @@ $(function(){
         toggleFanCTRL();
     });
 
+    // Set a deterministic initial state to avoid settings text flashing on first paint.
+    $('.fanctrl-settings').hide();
+    $('.fanctrl-basic').show();
     toggleFanCTRL();
 
     // toggle auto disables settings
+    function syncSpindownDetailState(fanSuffix) {
+        var primarySelector = "select[name='TEMP_" + fanSuffix + "']";
+        var spindownSelector = "select[name='TEMPHDD_" + fanSuffix + "']";
+        var detailClass = '.fan-spindown-' + fanSuffix;
+        var spindownValue = parseInt($(spindownSelector).val() || '0', 10);
+        var showDetails = ($(primarySelector).val() === '99') && (spindownValue > 0) && !$(spindownSelector).prop('disabled');
+        $(detailClass).toggle(showDetails);
+    }
+
+    function syncHddSpindownSensorState(tempSelect) {
+        var tempName = $(tempSelect).attr('name') || '';
+        if (tempName.indexOf('TEMP_') !== 0 || tempName.indexOf('TEMPHDD_') === 0) {
+            return;
+        }
+
+        var fanSuffix = tempName.substring(5);
+        var spindownSelector = "select[name='TEMPHDD_" + fanSuffix + "']";
+        var enableSpindownSensor = ($(tempSelect).val() === '99');
+        $(spindownSelector).prop('disabled', !enableSpindownSensor);
+        syncSpindownDetailState(fanSuffix);
+    }
+
     $('.fanctrl-temp')
         .each(function() {
             var FanName = '.' + $(this).attr('name');
             $(FanName).prop('disabled', ($(this)[0].selectedIndex == 0));
+            syncHddSpindownSensorState(this);
+            var tempName = $(this).attr('name') || '';
+            if (tempName.indexOf('TEMPHDD_') === 0) {
+                syncSpindownDetailState(tempName.substring(8));
+            }
         })
         .on('change', function() {
             var FanName = '.' + $(this).attr('name');
             $(FanName).prop('disabled', ($(this)[0].selectedIndex == 0));
+            syncHddSpindownSensorState(this);
+            var tempName = $(this).attr('name') || '';
+            if (tempName.indexOf('TEMPHDD_') === 0) {
+                syncSpindownDetailState(tempName.substring(8));
+            }
         });
+
+    $('.fanctrl-enable')
+        .each(function() {
+            var fanClass = '.fan-config-' + $(this).data('fan');
+            $(fanClass).toggle($(this).val() !== '0');
+            $(this).closest('.fan-block').attr('data-enabled', ($(this).val() === '0') ? '0' : '1');
+        })
+        .on('change', function() {
+            var fanClass = '.fan-config-' + $(this).data('fan');
+            $(fanClass).toggle($(this).val() !== '0');
+            $(this).closest('.fan-block').attr('data-enabled', ($(this).val() === '0') ? '0' : '1');
+            sortFanBlocks();
+        });
+
+    sortFanBlocks();
 
     $('#btnConfig').click(function() {
                 openBox('/plugins/ipmi/scripts/ipmi2json', 'IPMI Fan Config', 600, 900, true);
@@ -286,6 +336,19 @@ function initDriveDropdown(remove) {
     DDCheckList('#select-drives','#HDDIGNORE');
 }
 
+function sortFanBlocks() {
+    var fanBlocks = $('.fan-block').get();
+    fanBlocks.sort(function(a, b) {
+        var aEnabled = parseInt($(a).attr('data-enabled') || '1', 10);
+        var bEnabled = parseInt($(b).attr('data-enabled') || '1', 10);
+        return bEnabled - aEnabled;
+    });
+
+    $.each(fanBlocks, function(_, block) {
+        $(block).appendTo('#fanctrl-options');
+    });
+}
+
 function checkFANCTRL() {
     if ($('#FANCONTROL')[0].selectedIndex < 1 ) {
         $('#FANCMD').val('/usr/local/emhttp/plugins/ipmi/scripts/fanctrl_stop');
@@ -312,11 +375,11 @@ function checkBoard() {
 
 function toggleFanCTRL() {
     if ($.cookie('fanctrl_view_mode') == 'advanced') {
-        $('.fanctrl-settings').show('slow');
-        $('.fanctrl-basic').hide('slow');
+        $('.fanctrl-settings').show();
+        $('.fanctrl-basic').hide();
     }else{
-        $('.fanctrl-basic').show('slow');
-        $('.fanctrl-settings').hide('slow');
+        $('.fanctrl-basic').show();
+        $('.fanctrl-settings').hide();
     }
 }
 <?endif;?>

--- a/source/ipmi/usr/local/emhttp/plugins/ipmi/include/ipmi_check.php
+++ b/source/ipmi/usr/local/emhttp/plugins/ipmi/include/ipmi_check.php
@@ -1,7 +1,22 @@
 <?
 /* board info */
-$boards = ['ASRock'=>'','ASRockRack'=>'', 'Dell' =>'','Supermicro'=>''];
+$boards = ['ASRock'=>'','ASRockRack'=>'', 'Dell' =>'','Supermicro'=>'','Giga'=>''];
 $board  = ( $override == 'disable') ? trim(shell_exec("dmidecode -t 2 | grep 'Manufacturer' | awk -F 'r:' '{print $2}' | awk  '{print $1}'")) : $oboard;
+$board_raw = $board;
+
+// Normalize vendor names returned by dmidecode to the canonical board keys used by this plugin.
+if (stripos($board_raw, 'GIGA') === 0) {
+  $board = 'Giga';
+} elseif (strcasecmp($board_raw, 'ASRock') === 0) {
+  $board = 'ASRock';
+} elseif (strcasecmp($board_raw, 'ASRockRack') === 0) {
+  $board = 'ASRockRack';
+} elseif (strcasecmp($board_raw, 'Supermicro') === 0) {
+  $board = 'Supermicro';
+} elseif (strcasecmp($board_raw, 'Dell') === 0) {
+  $board = 'Dell';
+}
+
 $board_model = ( $override == 'disable') ? rtrim(ltrim(shell_exec("dmidecode -qt2|awk -F: '/^\tProduct Name:/ {print $2}'"))) : $omodel;
 $board_status  = array_key_exists($board, $boards);
 $sm_gen="";

--- a/source/ipmi/usr/local/emhttp/plugins/ipmi/include/ipmi_helpers.php
+++ b/source/ipmi/usr/local/emhttp/plugins/ipmi/include/ipmi_helpers.php
@@ -375,12 +375,19 @@ function get_fanctrl_options(){
                 echo '<input type="hidden" name="FAN_',$name,'" value="',$id,'"/>';
 
                 // fan name: reading => temp name: reading
-                echo '<dl><dt>',$display,' (',floatval($fan['Reading']),' ',$fan['Units'],'):</dt><span class="fanctrl-basic">';
+                echo '<dl><dt>',$display,' (',floatval($fan['Reading']),' ',$fan['Units'],'):</dt><dd><span class="fanctrl-basic">';
                 if (!$fanenabled) {
                     echo 'Disabled';
+                } else {
+                    if ($temp['Name']){
+                        echo $temp['Name'],' ('.my_temp(floatval($temp['Reading'])),' ','), ',
+                        $fancfg[$templo],'-',$fancfg[$temphi],'&deg;, ',number_format((intval(intval($fancfg[$fanmin])/$range*1000)/10),1),'-',number_format((intval(intval($fancfg[$fanmax])/$range*1000)/10),1),'%';
+                    }else{
+                        echo 'Auto';
+                    }
                 }
 
-                echo '</span><span class="fanctrl-settings">';
+                echo '</span><span class="fanctrl-settings" style="display:none;">';
                 if ($fanenabled) {
                     if ($temp['Name']){
                         echo $temp['Name'],' ('.my_temp(floatval($temp['Reading'])),' ','), ',
@@ -399,7 +406,7 @@ function get_fanctrl_options(){
                 } else {
                     echo '&nbsp;';
                 }
-                echo '</span>';
+                echo '</span></dd>';
 
                 // check if board.json exists then if fan name is in board.json
                 $noconfig = '<font class="red"><b><i> (fan is not configured!)</i></b></font>';
@@ -415,11 +422,11 @@ function get_fanctrl_options(){
                     echo $noconfig;
                 }
 
-                echo '</dd></dl>';
+                echo '</dl>';
 
                 // enable or disable this fan in fan control
                 echo '<dl class="fanctrl-settings">',
-                '<dt><dl><dd>Use in fan control:</dd></dl></dt><dd>',
+                '<dt>Use in fan control:</dt><dd>',
                 '<select name="',$fanenable,'" class="fanctrl-enable" data-fan="',$name,'">',
                 '<option value="1"', ($fanenabled ? ' selected' : ''), '>Enabled</option>',
                 '<option value="0"', (!$fanenabled ? ' selected' : ''), '>Disabled</option>',
@@ -427,7 +434,7 @@ function get_fanctrl_options(){
 
                 // temperature sensor
                 echo '<dl class="fanctrl-settings ',$fanconfigclass,'"',$fanhide,'>',
-                '<dt><dl><dd>Temperature sensor:</dd></dl></dt><dd>',
+                '<dt>Temperature sensor:</dt><dd>',
                 '<select name="',$tempid,'" class="fanctrl-temp fanctrl-settings">',
                 '<option value="0">Auto</option>',
                 get_temp_options($fancfg[$tempid]),
@@ -437,64 +444,64 @@ function get_fanctrl_options(){
 
                 // high temperature threshold
                                 echo '<dl class="fanctrl-settings ',$fanconfigclass,'"',$fanhide,'>',
-                '<dt><dl><dd>High temperature threshold (&deg;'.$display_unit.'):</dd></dl></dt>',
+                '<dt>High temperature threshold (&deg;'.$display_unit.'):</dt>',
                 '<dd><select name="',$temphi,'" class="',$tempid,' fanctrl-settings">',
                 get_temp_range('HI', $fancfg[$temphi],$display_unit),
                 '</select></dd></dl>';
 
                 // low temperature threshold
                                 echo '<dl class="fanctrl-settings ',$fanconfigclass,'"',$fanhide,'>',
-                '<dt><dl><dd>Low temperature threshold (&deg;'.$display_unit.'):</dd></dl></dt>',
+                '<dt>Low temperature threshold (&deg;'.$display_unit.'):</dt>',
                 '<dd><select name="',$templo,'" class="',$tempid,' fanctrl-settings">',
                 get_temp_range('LO', $fancfg[$templo],$display_unit),
                 '</select></dd></dl>';
 
                 // fan control maximum speed
                                 echo '<dl class="fanctrl-settings ',$fanconfigclass,'"',$fanhide,'>',
-                '<dt><dl><dd>Fan speed maximum (%):</dd></dl></dt><dd>',
+                '<dt>Fan speed maximum (%):</dt><dd>',
                 '<select name="',$fanmax,'" class="',$tempid,' fanctrl-settings">',
                 get_minmax_options('HI', $fancfg[$fanmax]),
                 '</select></dd></dl>';
 
                 // fan control minimum speed
                                 echo '<dl class="fanctrl-settings ',$fanconfigclass,'"',$fanhide,'>',
-                '<dt><dl><dd>Fan speed minimum (%):</dd></dl></dt><dd>',
+                '<dt>Fan speed minimum (%):</dt><dd>',
                 '<select name="',$fanmin,'" class="',$tempid,' fanctrl-settings">',
                 get_minmax_options('LO', $fancfg[$fanmin]),
                 '</select></dd></dl>&nbsp;';
        
                 // temperature sensor Spundown
-                                echo '<dl class="fanctrl-settings ',$fanconfigclass,'"',$fanhide,'>',
-                '<dt><dl><dd>HDD Spundown Temperature sensor:</dd></dl></dt><dd>',
+                                                                echo '<dl class="fanctrl-settings ',$fanconfigclass,'"',$fanhide,'>',
+                                '<dt>HDD Spundown Temperature sensor:</dt><dd>',
                 '<select', $disabled, ' name="', $temphdd, '" class="fanctrl-temp fanctrl-settings">',
                 '<option value="0">None</option>',
                 get_temp_options($fancfg[$temphdd]),
                 '</select></dd></dl>';
 
                 // high temperature threshold Spundown
-                                                                echo '<dl class="fanctrl-settings ',$fanconfigclass,' ',$spindownconfigclass,'"',$spindownhide,'>',
-                '<dt><dl><dd>High temperature threshold Spundown (&deg;', $display_unit, '):</dd></dl></dt>',
+                                                                                                                                echo '<dl class="fanctrl-settings ',$fanconfigclass,' ',$spindownconfigclass,'"',$spindownhide,'>',
+                                '<dt>High temperature threshold Spundown (&deg;', $display_unit, '):</dt>',
                 '<dd><select name="', $temphio, '" class="', $tempid, ' fanctrl-settings">',
                 get_temp_range('HI', $fancfg[$temphio], $display_unit),
                 '</select></dd></dl>';
 
                 // low temperature threshold Spundown
-                                                         echo '<dl class="fanctrl-settings ',$fanconfigclass,' ',$spindownconfigclass,'"',$spindownhide,'>',
-               '<dt><dl><dd>Low temperature threshold Spundown (&deg;', $display_unit, '):</dd></dl></dt>',
+                                                                                                                 echo '<dl class="fanctrl-settings ',$fanconfigclass,' ',$spindownconfigclass,'"',$spindownhide,'>',
+                             '<dt>Low temperature threshold Spundown (&deg;', $display_unit, '):</dt>',
                '<dd><select name="', $temploo, '" class="', $tempid, ' fanctrl-settings">',
                get_temp_range('LO', $fancfg[$temploo], $display_unit),
                '</select></dd></dl>';
 
                // fan control maximum speed Spundown
-                                                         echo '<dl class="fanctrl-settings ',$fanconfigclass,' ',$spindownconfigclass,'"',$spindownhide,'>',
-               '<dt><dl><dd>Fan speed maximum Spundown (%):</dd></dl></dt><dd>',
+                                                                                                                 echo '<dl class="fanctrl-settings ',$fanconfigclass,' ',$spindownconfigclass,'"',$spindownhide,'>',
+                             '<dt>Fan speed maximum Spundown (%):</dt><dd>',
                '<select name="', $fanmaxo, '" class="', $tempid, ' fanctrl-settings">',
                get_minmax_options('HI', $fancfg[$fanmaxo]),
                '</select></dd></dl>';
 
               // fan control minimum speed Spundown
-                                                        echo '<dl class="fanctrl-settings ',$fanconfigclass,' ',$spindownconfigclass,'"',$spindownhide,'>',
-              '<dt><dl><dd>Fan speed minimum Spundown (%):</dd></dl></dt><dd>',
+                                                                                                                echo '<dl class="fanctrl-settings ',$fanconfigclass,' ',$spindownconfigclass,'"',$spindownhide,'>',
+                            '<dt>Fan speed minimum Spundown (%):</dt><dd>',
               '<select name="', $fanmino, '" class="', $tempid, ' fanctrl-settings">',
               get_minmax_options('LO', $fancfg[$fanmino]),
             '</select></dd></dl>&nbsp;';

--- a/source/ipmi/usr/local/emhttp/plugins/ipmi/include/ipmi_helpers.php
+++ b/source/ipmi/usr/local/emhttp/plugins/ipmi/include/ipmi_helpers.php
@@ -361,27 +361,45 @@ function get_fanctrl_options(){
                 $temphio  = 'TEMPHIO_'.$name;
                 $fanmaxo  = 'FANMAXO_'.$name;
                 $fanmino  = 'FANMINO_'.$name;
+                $fanenable = 'FANENABLE_'.$name;
+                $fanenabled = !isset($fancfg[$fanenable]) || strval($fancfg[$fanenable]) !== '0';
+                $fanconfigclass = 'fan-config-'.$name;
+                $fanhide = $fanenabled ? '' : ' style="display:none;"';
+                $spindownconfigclass = 'fan-spindown-'.$name;
+                $showspindown = ($fanenabled && isset($fancfg[$tempid]) && strval($fancfg[$tempid]) === '99' && intval(isset($fancfg[$temphdd]) ? $fancfg[$temphdd] : 0) > 0);
+                $spindownhide = $showspindown ? '' : ' style="display:none;"';
+
+                echo '<div class="fan-block" data-fan="',$name,'" data-enabled="', ($fanenabled ? '1' : '0'), '">';
 
                 // hidden fan id
                 echo '<input type="hidden" name="FAN_',$name,'" value="',$id,'"/>';
 
                 // fan name: reading => temp name: reading
                 echo '<dl><dt>',$display,' (',floatval($fan['Reading']),' ',$fan['Units'],'):</dt><span class="fanctrl-basic">';
-                if ($temp['Name']){
-                    echo $temp['Name'],' ('.my_temp(floatval($temp['Reading'])),' ','), ',
-                    $fancfg[$templo],', ',$fancfg[$temphi],', ',number_format((intval(intval($fancfg[$fanmin])/$range*1000)/10),1),'-',number_format((intval(intval($fancfg[$fanmax])/$range*1000)/10),1),'%';
-                }else{
-                    echo 'Auto';
+                if (!$fanenabled) {
+                    echo 'Disabled';
                 }
-                
-                echo $display,' (',floatval($fan['Reading']),' ',$fan['Units'],'):';
-                if (isset($temphddd['Name'])){
-                    echo "&nbsp;&nbsp;&nbsp;&nbsp;Override:".$temphddd['Name'].' ('.my_temp(floatval($temp['Reading'])),' ','), ',
-                    $fancfg[$temploo],', ',$fancfg[$temphio],', ',number_format((intval(intval($fancfg[$fanmino])/$range*1000)/10),1),'-',number_format((intval(intval($fancfg[$fanmaxo])/$range*1000)/10),1),'%';
-                }else{
-                    echo 'Not Defined';
+
+                echo '</span><span class="fanctrl-settings">';
+                if ($fanenabled) {
+                    if ($temp['Name']){
+                        echo $temp['Name'],' ('.my_temp(floatval($temp['Reading'])),' ','), ',
+                        $fancfg[$templo],', ',$fancfg[$temphi],', ',number_format((intval(intval($fancfg[$fanmin])/$range*1000)/10),1),'-',number_format((intval(intval($fancfg[$fanmax])/$range*1000)/10),1),'%';
+                    }else{
+                        echo 'Auto';
+                    }
+
+                    echo '&nbsp;&nbsp;&nbsp;&nbsp;Override:';
+                    if (isset($temphddd['Name'])){
+                        echo $temphddd['Name'].' ('.my_temp(floatval($temp['Reading'])),' ','), ',
+                        $fancfg[$temploo],', ',$fancfg[$temphio],', ',number_format((intval(intval($fancfg[$fanmino])/$range*1000)/10),1),'-',number_format((intval(intval($fancfg[$fanmaxo])/$range*1000)/10),1),'%';
+                    }else{
+                        echo 'Not Defined';
+                    }
+                } else {
+                    echo '&nbsp;';
                 }
-                echo '</span><span class="fanctrl-settings">&nbsp;</span>';
+                echo '</span>';
 
                 // check if board.json exists then if fan name is in board.json
                 $noconfig = '<font class="red"><b><i> (fan is not configured!)</i></b></font>';
@@ -399,8 +417,16 @@ function get_fanctrl_options(){
 
                 echo '</dd></dl>';
 
-                // temperature sensor
+                // enable or disable this fan in fan control
                 echo '<dl class="fanctrl-settings">',
+                '<dt><dl><dd>Use in fan control:</dd></dl></dt><dd>',
+                '<select name="',$fanenable,'" class="fanctrl-enable" data-fan="',$name,'">',
+                '<option value="1"', ($fanenabled ? ' selected' : ''), '>Enabled</option>',
+                '<option value="0"', (!$fanenabled ? ' selected' : ''), '>Disabled</option>',
+                '</select></dd></dl>';
+
+                // temperature sensor
+                echo '<dl class="fanctrl-settings ',$fanconfigclass,'"',$fanhide,'>',
                 '<dt><dl><dd>Temperature sensor:</dd></dl></dt><dd>',
                 '<select name="',$tempid,'" class="fanctrl-temp fanctrl-settings">',
                 '<option value="0">Auto</option>',
@@ -410,71 +436,70 @@ function get_fanctrl_options(){
                 if ($fancfg[$tempid] == "99") $disabled = "" ; else $disabled = " disabled ";
 
                 // high temperature threshold
-                echo '<dl class="fanctrl-settings">',
+                                echo '<dl class="fanctrl-settings ',$fanconfigclass,'"',$fanhide,'>',
                 '<dt><dl><dd>High temperature threshold (&deg;'.$display_unit.'):</dd></dl></dt>',
                 '<dd><select name="',$temphi,'" class="',$tempid,' fanctrl-settings">',
                 get_temp_range('HI', $fancfg[$temphi],$display_unit),
                 '</select></dd></dl>';
 
                 // low temperature threshold
-                echo '<dl class="fanctrl-settings">',
+                                echo '<dl class="fanctrl-settings ',$fanconfigclass,'"',$fanhide,'>',
                 '<dt><dl><dd>Low temperature threshold (&deg;'.$display_unit.'):</dd></dl></dt>',
                 '<dd><select name="',$templo,'" class="',$tempid,' fanctrl-settings">',
                 get_temp_range('LO', $fancfg[$templo],$display_unit),
                 '</select></dd></dl>';
 
                 // fan control maximum speed
-                echo '<dl class="fanctrl-settings">',
+                                echo '<dl class="fanctrl-settings ',$fanconfigclass,'"',$fanhide,'>',
                 '<dt><dl><dd>Fan speed maximum (%):</dd></dl></dt><dd>',
                 '<select name="',$fanmax,'" class="',$tempid,' fanctrl-settings">',
                 get_minmax_options('HI', $fancfg[$fanmax]),
                 '</select></dd></dl>';
 
                 // fan control minimum speed
-                echo '<dl class="fanctrl-settings">',
+                                echo '<dl class="fanctrl-settings ',$fanconfigclass,'"',$fanhide,'>',
                 '<dt><dl><dd>Fan speed minimum (%):</dd></dl></dt><dd>',
                 '<select name="',$fanmin,'" class="',$tempid,' fanctrl-settings">',
                 get_minmax_options('LO', $fancfg[$fanmin]),
                 '</select></dd></dl>&nbsp;';
        
                 // temperature sensor Spundown
-                echo '<dl class="fanctrl-settings">',
+                                echo '<dl class="fanctrl-settings ',$fanconfigclass,'"',$fanhide,'>',
                 '<dt><dl><dd>HDD Spundown Temperature sensor:</dd></dl></dt><dd>',
                 '<select', $disabled, ' name="', $temphdd, '" class="fanctrl-temp fanctrl-settings">',
                 '<option value="0">None</option>',
                 get_temp_options($fancfg[$temphdd]),
                 '</select></dd></dl>';
 
-                // Check if the Spundown values should be shown
-                if ($fancfg[$temphdd] != 0) {
                 // high temperature threshold Spundown
-                echo '<dl class="fanctrl-settings">',
+                                                                echo '<dl class="fanctrl-settings ',$fanconfigclass,' ',$spindownconfigclass,'"',$spindownhide,'>',
                 '<dt><dl><dd>High temperature threshold Spundown (&deg;', $display_unit, '):</dd></dl></dt>',
                 '<dd><select name="', $temphio, '" class="', $tempid, ' fanctrl-settings">',
                 get_temp_range('HI', $fancfg[$temphio], $display_unit),
                 '</select></dd></dl>';
 
                 // low temperature threshold Spundown
-               echo '<dl class="fanctrl-settings">',
+                                                         echo '<dl class="fanctrl-settings ',$fanconfigclass,' ',$spindownconfigclass,'"',$spindownhide,'>',
                '<dt><dl><dd>Low temperature threshold Spundown (&deg;', $display_unit, '):</dd></dl></dt>',
                '<dd><select name="', $temploo, '" class="', $tempid, ' fanctrl-settings">',
                get_temp_range('LO', $fancfg[$temploo], $display_unit),
                '</select></dd></dl>';
 
                // fan control maximum speed Spundown
-               echo '<dl class="fanctrl-settings">',
+                                                         echo '<dl class="fanctrl-settings ',$fanconfigclass,' ',$spindownconfigclass,'"',$spindownhide,'>',
                '<dt><dl><dd>Fan speed maximum Spundown (%):</dd></dl></dt><dd>',
                '<select name="', $fanmaxo, '" class="', $tempid, ' fanctrl-settings">',
                get_minmax_options('HI', $fancfg[$fanmaxo]),
                '</select></dd></dl>';
 
               // fan control minimum speed Spundown
-              echo '<dl class="fanctrl-settings">',
+                                                        echo '<dl class="fanctrl-settings ',$fanconfigclass,' ',$spindownconfigclass,'"',$spindownhide,'>',
               '<dt><dl><dd>Fan speed minimum Spundown (%):</dd></dl></dt><dd>',
               '<select name="', $fanmino, '" class="', $tempid, ' fanctrl-settings">',
               get_minmax_options('LO', $fancfg[$fanmino]),
             '</select></dd></dl>&nbsp;';
-            }
+
+                                echo '</div>';
 
                 $i++;
             }

--- a/source/ipmi/usr/local/emhttp/plugins/ipmi/include/ipmi_settings_fan.php
+++ b/source/ipmi/usr/local/emhttp/plugins/ipmi/include/ipmi_settings_fan.php
@@ -115,6 +115,26 @@ switch($board) {
       ]
     ]
 ]; */
+  case 'Giga':
+  $board_file_status = true;
+    $range = 255;
+    $board_json = [ 'Giga' =>
+            [ 'raw'    => '00 2e 10 0a 3c 00 40 01', # + value 0-255 for speed and ID A0-A6
+              'auto'   => '00 2e 10 0a 3c 00 40 00 00 00',
+              'manual' => '00 2e 10 0a 3c 00 40 00 00 00',
+              'full'   => '00 2e 10 0a 3c 00 40 00 00 00',
+              'fans'   => [
+                'CPU0_FAN' => 'A0',
+                'SYS_FAN1' => 'A1',
+                'SYS_FAN2' => 'A2',
+                'SYS_FAN3' => 'A3',
+                'SYS_FAN4' => 'A4',
+                'SYS_FAN5' => 'A5',
+                'SYS_FAN6' => 'A6',
+              ]
+        ]
+    ];
+    break;
 }
 
 // fan network options base64_decode(

--- a/source/ipmi/usr/local/emhttp/plugins/ipmi/scripts/ipmifan
+++ b/source/ipmi/usr/local/emhttp/plugins/ipmi/scripts/ipmifan
@@ -27,6 +27,7 @@ Usage: $prog [options]
 
   -a, --auto       set fans to auto
       --full       set fans to full speed
+    -n, --dryrun     output checks only; do not send fan commands
   -q, --quiet      suppress all messages
       --debug      turn on debugging
       --daemon     run in the background
@@ -37,10 +38,11 @@ Usage: $prog [options]
 
 EOF;
 
-$shortopts = 'adfq';
+$shortopts = 'adfqn';
 $longopts = [
     'auto',
     'daemon',
+    'dryrun',
     'debug',
     'full',
     'help',
@@ -62,6 +64,7 @@ if (array_key_exists('version', $args)) {
 
 $arga   = (array_key_exists('a', $args) || array_key_exists('auto', $args));
 $argf   = (array_key_exists('full', $args));
+$dryrun = (array_key_exists('n', $args) || array_key_exists('dryrun', $args));
 $argq   = (array_key_exists('q', $args) || array_key_exists('quiet', $args));
 $debug  = (array_key_exists('debug', $args));
 $daemon = (array_key_exists('d', $args) || array_key_exists('daemon', $args));
@@ -117,7 +120,19 @@ if (!$board_file_status) {
 }
 
 if($daemon){
-    exec("php $service 1>/dev/null ".($debug ? "":"2>&1 ")."&");
+    $daemon_args = [];
+    if ($dryrun)
+        $daemon_args[] = '--dryrun';
+    if ($debug)
+        $daemon_args[] = '--debug';
+    if ($argq)
+        $daemon_args[] = '--quiet';
+
+    $daemon_cmd = 'php '.escapeshellarg($service);
+    if (!empty($daemon_args))
+        $daemon_cmd .= ' '.implode(' ', $daemon_args);
+
+    exec($daemon_cmd.' 1>/dev/null '.($debug ? '' : '2>&1 ').'&');
     syslog(LOG_INFO, "process started. To terminate it, type: $prog --quit");
     exit(0);
 }
@@ -185,6 +200,32 @@ if($daemon){
 # 01 - 64  = 1% - 100%
 #############################################
 
+
+#############################################
+# Gigabyte Model for SW34-SP0
+# raw    => '00 2e 10 0a 3c 00 40 01 CC BB', # + value 0-255 for speed and ID A0-A6
+# auto   => '00 2e 10 0a 3c 00 40 00 00 00', 
+# full   => '00 2e 10 0a 3c 00 40 01 FF FF',
+#
+# BB
+# A0 - CPU_FAN
+# A1 - SYS_FAN1
+# A2 - SYS_FAN2
+# A3 - SYS_FAN3
+# A4 - SYS_FAN4
+# A5 - SYS_FAN5
+# A6 - SYS_FAN6
+# FF - all fans 
+#
+# CC
+# 00 to FF - Set Speed (0-255)
+#
+# Fan duty is a value from 1-255, where 1 is 0% and 255 is 100%. The command sets manual mode inline.
+# No way to set individual fans to auto, but setting all fans to auto will override manual mode and set all fans to auto.
+#############################################
+
+
+
 ##############################
 ###### FUNCTION SECTION ######
 ##############################
@@ -215,7 +256,7 @@ function debug($m){
 
 /* auto fan */
 function autofan() {
-    global $board_json, $board, $board_model, $cmd_count, $fanopts;
+    global $board_json, $board, $board_model, $cmd_count, $fanopts, $dryrun;
     fanlog('Setting fans to auto');
     $cmd = '';
     switch($board) {
@@ -242,13 +283,23 @@ function autofan() {
             $auto = $board_json[$board]['auto'];
             $cmd   = "ipmi-raw $auto $fanopts 2>&1 >/dev/null &";
             break;
+        case "Giga":
+            //if board is Giga
+            $auto = $board_json[$board]['auto'];
+            $cmd  = "ipmi-raw $auto $fanopts 2>&1 >/dev/null &";
+            break;
     }
-    shell_exec($cmd);
+    if ($dryrun) {
+        fanlog('[DRYRUN] Skipping autofan command');
+        debug('[DRYRUN] autofan cmd: '.$cmd);
+    } else {
+        shell_exec($cmd);
+    }
 }
 
 /* manual fan */
 function manualfan() {
-    global $board_json, $board, $board_model, $cmd_count, $fanopts;
+    global $board_json, $board, $board_model, $cmd_count, $fanopts, $dryrun;
     fanlog('Setting fans to manual');
     $cmd = '';
     switch($board) {
@@ -276,13 +327,18 @@ function manualfan() {
             $cmd   = "ipmi-raw $manual $fanopts 2>&1 >/dev/null &";
             break;
     }
-    shell_exec($cmd);
+    if ($dryrun) {
+        fanlog('[DRYRUN] Skipping manualfan command');
+        debug('[DRYRUN] manualfan cmd: '.$cmd);
+    } else {
+        shell_exec($cmd);
+    }
     sleep(10) ;
 }
 
 /* full speed fan */
 function fullfan() {
-    global $board_json, $board, $board_model, $cmd_count, $fanopts;
+    global $board_json, $board, $board_model, $cmd_count, $fanopts, $dryrun;
     fanlog('Setting fans to full speed');
     switch($board) {
         case "ASRock":
@@ -306,9 +362,19 @@ function fullfan() {
             $raw    = $board_json[$board]['raw'];
             $full = $board_json[$board]['full'];
             $cmd   = "ipmi-raw $full $fanopts 2>&1 >/dev/null &";
-            break;  
+            break;
+        case "Giga":
+            //if board is Giga
+            $full = $board_json[$board]['full'];
+            $cmd  = "ipmi-raw $full $fanopts 2>&1 >/dev/null &";
+            break;
     }
-    echo shell_exec($cmd);
+    if ($dryrun) {
+        fanlog('[DRYRUN] Skipping fullfan command');
+        debug('[DRYRUN] fullfan cmd: '.$cmd);
+    } else {
+        echo shell_exec($cmd);
+    }
     sleep(10);
 }
 
@@ -396,16 +462,16 @@ $fan_count    = $fanpoll * 10;
 $hdd_count    = $hddpoll * 10;
 $curent_hex   = '';
 $current_hex2 = '';
+$current_pwm_giga = [];
 
 fanlog('Starting Fan Control');
 fanlog("Board: $board Board Model: $board_model");
+if($dryrun){
+    fanlog('Dry run mode enabled: checks will run, fan commands will not execute');
+}
 
 if($board == 'Supermicro'){
     fanlog("SM Board selection: $smboard_model");
-    fullfan();
-}
-if($board == 'Dell'){
-    manualfan();
 }
 
 while(TRUE){ while(TRUE){
@@ -436,7 +502,8 @@ while(TRUE){ while(TRUE){
 
         foreach($fans as $fan => $value){
 
-            $temp = isset($fancfg["TEMP_$fan"]) ? $fancfg["TEMP_$fan"] : '';
+            $fan_enabled = !isset($fancfg["FANENABLE_$fan"]) || strval($fancfg["FANENABLE_$fan"]) !== '0';
+            $temp = ($fan_enabled && isset($fancfg["TEMP_$fan"])) ? $fancfg["TEMP_$fan"] : '';
          #   echo "temp:".$temp;
             if(!empty($temp)) {
                 $templo  = (isset($fancfg["TEMPLO_$fan"])) ? intval($fancfg["TEMPLO_$fan"])  : 30;
@@ -450,7 +517,7 @@ while(TRUE){ while(TRUE){
                 $reading = floatval($sensors[$temp]['Reading']);
                 $name    = htmlspecialchars($sensors[$temp]['Name']);
                 $use_override = false;
-                if ($temp = "99" && $reading <= 0) {
+                if ($temp == "99" && $reading <= 0) {
                     if (isset($fancfg["TEMPHDD_$fan"]) &&  $fancfg["TEMPHDD_$fan"] != 0) {
                     $temp=    $fancfg["TEMPHDD_$fan"] ;
                     $reading = floatval($sensors[$temp]['Reading']);
@@ -516,7 +583,10 @@ while(TRUE){ while(TRUE){
                 if ($reading <= 0) $mytemp = "Spundown" ; else $mytemp = str_replace([" ","&#8201;&#176;"],["",""],my_temp($reading));
                 $msg .= ", {$fan}({$pct}%):".str_replace('Temperature','Temp',$name)."($mytemp)";
 
-           }else{
+         }else{
+             if (!$fan_enabled) {
+                $msg .= ", {$fan}(Disabled)";
+             }
                 $pwm ='00';
            }
 
@@ -574,6 +644,18 @@ while(TRUE){ while(TRUE){
                     $exec = true;
                 }
                 break;
+            case "Giga":
+                // each Giga fan is controlled independently and command sets manual mode inline
+                $giga_key = $board0.':'.$value;
+                if(!isset($current_pwm_giga[$giga_key]))
+                    $current_pwm_giga[$giga_key] = '';
+
+                if($current_pwm_giga[$giga_key] !== $pwm && $pwm !== '00'){
+                    $cmd .= "ipmi-raw $raw $pwm $value $fanopts 2>&1; ";
+                    $current_pwm_giga[$giga_key] = $pwm;
+                    $exec = true;
+                }
+                break;
             }
             $fan_count++;
         }
@@ -605,8 +687,12 @@ while(TRUE){ while(TRUE){
             break;
         }
 
-        // execute command if exec set
-        if($exec){
+        // execute command if exec set, or log checks in dryrun mode
+        if($dryrun){
+            if($cmd)
+                fanlog('[DRYRUN] '.$cmd);
+            fanlog('[DRYRUN] '.$msg);
+        } elseif($exec){
             shell_exec($cmd);
             #fanlog($cmd);
             if($debug)


### PR DESCRIPTION
This change adds support for the Gigabyte HW34-SP0.

It may support other machines, but would need to be tested.

#############################################
 Gigabyte Model for SW34-SP0
 raw    => '00 2e 10 0a 3c 00 40 01 CC BB', # + value 0-255 for speed and ID A0-A6
 auto   => '00 2e 10 0a 3c 00 40 00 00 00', 
 full   => '00 2e 10 0a 3c 00 40 01 FF FF',

 BB
 A0 - CPU_FAN
 A1 - SYS_FAN1
 A2 - SYS_FAN2
 A3 - SYS_FAN3
 A4 - SYS_FAN4
 A5 - SYS_FAN5
 A6 - SYS_FAN6
 FF - all fans 

 CC
 00 to FF - Set Speed (0-255)

 Fan duty is a value from 1-255, where 1 is 0% and 255 is 100%. The command sets manual mode inline.
 No way to set individual fans to auto, but setting all fans to auto will override manual mode and set all fans to auto.
#############################################

<img width="236" height="293" alt="image" src="https://github.com/user-attachments/assets/a38c727f-0b4c-495e-b16c-492633a03a7f" />
